### PR TITLE
Record segment file size in memory & Check data size.

### DIFF
--- a/segment.go
+++ b/segment.go
@@ -157,9 +157,9 @@ func (seg *segment) Write(data []byte) (*ChunkPosition, error) {
 		}
 
 		// A new block, clear the current block size.
+		seg.size += int64(blockSize - seg.currentBlockSize)
 		seg.currentBlockNumber += 1
 		seg.currentBlockSize = 0
-		seg.size += int64(blockSize - seg.currentBlockSize)
 	}
 
 	// the start position(for read operation)
@@ -264,12 +264,6 @@ func (seg *segment) readInternal(blockNumber uint32, chunkOffset int64) ([]byte,
 		return nil, nil, ErrClosed
 	}
 
-	//segSize, err := seg.fd.Seek(0, io.SeekEnd) // 1.96 - 2.07
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-	segSize := seg.size
-
 	var (
 		result    []byte
 		nextChunk = &ChunkPosition{SegmentId: seg.id}
@@ -277,8 +271,8 @@ func (seg *segment) readInternal(blockNumber uint32, chunkOffset int64) ([]byte,
 	for {
 		size := int64(blockSize)
 		offset := int64(blockNumber * blockSize)
-		if size+offset > segSize {
-			size = segSize - offset
+		if size+offset > seg.size {
+			size = seg.size - offset
 		}
 
 		if chunkOffset >= size {

--- a/segment.go
+++ b/segment.go
@@ -307,14 +307,14 @@ func (seg *segment) readInternal(blockNumber uint32, chunkOffset int64) ([]byte,
 		copy(header, block[chunkOffset:chunkOffset+chunkHeaderSize])
 
 		// length
-		legnth := binary.LittleEndian.Uint16(header[4:6])
+		length := binary.LittleEndian.Uint16(header[4:6])
 
 		// copy data
 		start := chunkOffset + chunkHeaderSize
-		result = append(result, block[start:start+int64(legnth)]...)
+		result = append(result, block[start:start+int64(length)]...)
 
 		// check sum
-		checksumEnd := chunkOffset + chunkHeaderSize + int64(legnth)
+		checksumEnd := chunkOffset + chunkHeaderSize + int64(length)
 		checksum := crc32.ChecksumIEEE(block[chunkOffset+4 : checksumEnd])
 		savedSum := binary.LittleEndian.Uint32(header[:4])
 		if savedSum != checksum {

--- a/wal.go
+++ b/wal.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,10 @@ import (
 
 const (
 	initialSegmentFileID = 1
+)
+
+var (
+	ErrTooLarge = errors.New("the data size can't larger than sigment size")
 )
 
 // WAL represents a Write-Ahead Log structure that provides durability
@@ -163,13 +168,15 @@ func (r *Reader) Next() ([]byte, *ChunkPosition, error) {
 func (wal *WAL) Write(data []byte) (*ChunkPosition, error) {
 	wal.mu.Lock()
 	defer wal.mu.Unlock()
-
+	if int64(len(data))+chunkHeaderSize > wal.options.SegmentSize {
+		return nil, ErrTooLarge
+	}
 	// if the active segment file is full, sync it and create a new one.
 	if wal.isFull(int64(len(data))) {
 		if err := wal.activeSegment.Sync(); err != nil {
 			return nil, err
 		}
-
+		wal.bytesWrite = 0
 		segment, err := openSegmentFile(wal.options.DirPath, wal.activeSegment.id+1, wal.blockCache)
 		if err != nil {
 			return nil, err

--- a/wal_test.go
+++ b/wal_test.go
@@ -75,12 +75,15 @@ func TestWAL_Write_large2(t *testing.T) {
 
 func testWriteAndIterate(t *testing.T, wal *WAL, size int, valueSize int) {
 	val := strings.Repeat("wal", valueSize)
+	totalWrite := 0.0
 	positions := make([]*ChunkPosition, size)
 	for i := 0; i < size; i++ {
 		pos, err := wal.Write([]byte(val))
+		totalWrite += float64(len(val))
 		assert.Nil(t, err)
 		positions[i] = pos
 	}
+	t.Logf("total write: %.4fMB\n", totalWrite/1024/1024)
 
 	var count int
 	// iterates all the data


### PR DESCRIPTION
1. It seems that the limitation of segment file size won't work when data size larger than option.SegmentSize, so I added some checks.
2. readInternal will take 2 system calls (Seek & WriteAt) when use Seek to get the file size, maybe use a field (seg.size) to record it is a better way? 
3. fix some spelling errors.