### PR TITLE
fix: limit data size

### DIFF
--- a/wal.go
+++ b/wal.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,10 @@ import (
 
 const (
 	initialSegmentFileID = 1
+)
+
+var (
+	ErrTooLarge = errors.New("the data size can't larger than sigment size")
 )
 
 // WAL represents a Write-Ahead Log structure that provides durability
@@ -215,13 +220,15 @@ func (r *Reader) Next() ([]byte, *ChunkPosition, error) {
 func (wal *WAL) Write(data []byte) (*ChunkPosition, error) {
 	wal.mu.Lock()
 	defer wal.mu.Unlock()
-
+	if int64(len(data))+chunkHeaderSize > wal.options.SegmentSize {
+		return nil, ErrTooLarge
+	}
 	// if the active segment file is full, sync it and create a new one.
 	if wal.isFull(int64(len(data))) {
 		if err := wal.activeSegment.Sync(); err != nil {
 			return nil, err
 		}
-
+		wal.bytesWrite = 0
 		segment, err := openSegmentFile(wal.options.DirPath, wal.options.SementFileExt,
 			wal.activeSegment.id+1, wal.blockCache)
 		if err != nil {

--- a/wal.go
+++ b/wal.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	ErrTooLarge = errors.New("the data size can't larger than sigment size")
+	ErrValueTooLarge = errors.New("the data size can't larger than segment size")
 )
 
 // WAL represents a Write-Ahead Log structure that provides durability
@@ -221,7 +221,7 @@ func (wal *WAL) Write(data []byte) (*ChunkPosition, error) {
 	wal.mu.Lock()
 	defer wal.mu.Unlock()
 	if int64(len(data))+chunkHeaderSize > wal.options.SegmentSize {
-		return nil, ErrTooLarge
+		return nil, ErrValueTooLarge
 	}
 	// if the active segment file is full, sync it and create a new one.
 	if wal.isFull(int64(len(data))) {


### PR DESCRIPTION
1. data size can't larger than segment size.
2. when  sync called, wal.bytesWrite should always be assigned to 0.