### PR TITLE
Improved performance for writing large records (> blockSize)

### DIFF
--- a/benchmark/bench_test.go
+++ b/benchmark/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -30,6 +31,16 @@ func BenchmarkWAL_Write(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_, err := walFile.Write([]byte("Hello World"))
+		assert.Nil(b, err)
+	}
+}
+
+func BenchmarkWAL_WriteBig(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := walFile.Write([]byte(strings.Repeat("X", 256*wal.KB+500)))
 		assert.Nil(b, err)
 	}
 }

--- a/benchmark/bench_test.go
+++ b/benchmark/bench_test.go
@@ -38,9 +38,9 @@ func BenchmarkWAL_Write(b *testing.B) {
 func BenchmarkWAL_WriteBig(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
-
+	content := []byte(strings.Repeat("X", 256*wal.KB+500))
 	for i := 0; i < b.N; i++ {
-		_, err := walFile.Write([]byte(strings.Repeat("X", 256*wal.KB+500)))
+		_, err := walFile.Write(content)
 		assert.Nil(b, err)
 	}
 }

--- a/segment.go
+++ b/segment.go
@@ -251,6 +251,7 @@ func (seg *segment) Write(data []byte) (*ChunkPosition, error) {
 	}
 
 	position.ChunkSize = blockCount*chunkHeaderSize + dataSize
+
 	return position, nil
 }
 


### PR DESCRIPTION
#20 
improved performance for writing records which are bigger than the blockSize (32K), by using the one reused buffer, since writing is synchronized we can reuse chunkBuffer after each write. i've decided to initialize chunkBuffer with size of 32k and its capacity will grow as long as new larger records are coming in. this behavior is same with bytebuffer pool.
so there is a trade-off i see here between:

1. keep the same behavior which is write multiple times for large records but keep re-using a buffer with max capacity of blockSize.

OR

2.  optimize for a single i/o sys call but maintain a buffer that can grow indefinitely (and might cause OOM).

also removed redundant chunk slice allocations.

all tests passed and also added new benchmark 

before:
![image](https://github.com/rosedblabs/wal/assets/74831037/e9d2ff7d-6901-49c8-9278-c4eaa54b4e65)

after:
![image](https://github.com/rosedblabs/wal/assets/74831037/a4ea4aa0-f12f-4570-9ac5-8b773389fff5)
