### PR TITLE
Modify the process for seg.closed & Use of formalised uniform byte units & Modify the description of the openSegmentFile function

### DIFF
--- a/options.go
+++ b/options.go
@@ -47,7 +47,7 @@ const (
 
 var DefaultOptions = Options{
 	DirPath:        os.TempDir(),
-	SegmentSize:    GB,
+	SegmentSize:    1 * GB,
 	SegmentFileExt: ".SEG",
 	Sync:           false,
 	BytesPerSync:   0,

--- a/segment.go
+++ b/segment.go
@@ -100,7 +100,7 @@ func putBuffer(buf []byte) {
 	blockPool.Put(buf)
 }
 
-// openSegmentFile a new segment file.
+// openSegmentFile a segment file.
 func openSegmentFile(dirPath, extName string, id uint32) (*segment, error) {
 	fd, err := os.OpenFile(
 		SegmentFileName(dirPath, extName, id),

--- a/segment.go
+++ b/segment.go
@@ -100,7 +100,7 @@ func putBuffer(buf []byte) {
 	blockPool.Put(buf)
 }
 
-// openSegmentFile a segment file.
+// openSegmentFile open a segment file.
 func openSegmentFile(dirPath, extName string, id uint32) (*segment, error) {
 	fd, err := os.OpenFile(
 		SegmentFileName(dirPath, extName, id),

--- a/segment.go
+++ b/segment.go
@@ -154,10 +154,10 @@ func (seg *segment) Sync() error {
 // Remove removes the segment file.
 func (seg *segment) Remove() error {
 	if !seg.closed {
-		seg.closed = true
 		if err := seg.fd.Close(); err != nil {
 			return err
 		}
+		seg.closed = true
 	}
 
 	return os.Remove(seg.fd.Name())

--- a/segment.go
+++ b/segment.go
@@ -168,9 +168,11 @@ func (seg *segment) Close() error {
 	if seg.closed {
 		return nil
 	}
-
+	if err := seg.fd.Close(); err != nil {
+		return err
+	}
 	seg.closed = true
-	return seg.fd.Close()
+	return nil
 }
 
 // Size returns the size of the segment file.


### PR DESCRIPTION
Hi, this PR contains a three-part modification.

PART 1：Modify the Remove & Close function for segment.go
I think the "seg.closed" for segment files should be set to "false" after calling "seg.fd.Close()". To avoid the case where closing the segment file fails, but the "seg.closed" is set to true.

PART 2：Use of formalised uniform byte units
Just change “GB” to “1 * GB” when using byte constants. This has the advantage that byte constants can be used as units.

PART 3：Modify the description of the openSegmentFile function for segment.go
From the wal.go, it looks like openSegmentFile is used to open both new and old segment file.  Simply change "openSegmentFile a new segment file." to "openSegmentFile open a segment file."

